### PR TITLE
Add missing fonts thanks to Typekit

### DIFF
--- a/source/_typekit.html.erb
+++ b/source/_typekit.html.erb
@@ -1,0 +1,2 @@
+<script type="text/javascript" src="//use.typekit.net/jeu5aub.js"></script>
+<script type="text/javascript">try{Typekit.load();}catch(e){}</script>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -27,6 +27,7 @@
 
     <%= javascript_include_tag "vendor/modernizr-2.6.1.min" %>
     <%= javascript_include_tag "application" %>
+    <%= partial 'typekit' %>
 
   </head>
   <body>


### PR DESCRIPTION
I don't know if there is any "branding" requirements for this, but typography was broken. 
The fonts `proxima-nova` and `kulturista` were set in scss styles, but not available.
I added those to a TypeKit account for RuLu.
After:
![screen shot 2014-04-20 at 17 39 49](https://cloud.githubusercontent.com/assets/224928/2750880/fa3ed9ce-c8a2-11e3-921a-81918d938472.png)

Before:
![screen shot 2014-04-20 at 17 45 19](https://cloud.githubusercontent.com/assets/224928/2750881/fede3970-c8a2-11e3-84ae-853382d8b80c.png)
